### PR TITLE
Update overcommit hooks

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -17,11 +17,14 @@
 
 PreCommit:
   Rubocop:
+    enabled: true
     on_warn: fail # Treat all warnings as failures
 
   TrailingWhitespace:
+    enabled: true
 
   Foodcritic:
+    enabled: true
 
   ShellCheck:
     enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :integration do
 end
 
 group :development do
-  gem 'overcommit', '~> 0.23.0'
+  gem 'overcommit'
   gem 'guard',  '~> 2.8.0'
   gem 'guard-kitchen', '~> 0.0.2'
   gem 'guard-rubocop',  '~> 1.2.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'devops@optoro.com'
 license 'MIT'
 description 'This is a skeleton'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.14'
+version '0.0.15'
 
 supports 'ubuntu', '= 14.04'
 


### PR DESCRIPTION
Removed version constraint on overcommit that was preventing the
registration of pre-commit hooks when signing. Also explicitly enabled
the hooks in the .overcommit.yml file.