### PR TITLE
[DO-1043] Add kitchen-joyent gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :integration do
   gem 'kitchen-ec2', '~> 0.10.0'
   gem 'kitchen-docker', '~> 1.5.0'
   gem 'kitchen-vagrant', '~> 0.15.0'
+  gem 'kitchen-joyent', '~> 0.2.2'
 end
 
 group :development do

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'devops@optoro.com'
 license 'MIT'
 description 'This is a skeleton'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.18'
+version '0.0.20'
 
 supports 'ubuntu', '= 14.04'
 


### PR DESCRIPTION
This change adds the `kitchen-joyent` gem to the bundle. It's necessary to run
kitchen tests on Joyent.