### PR TITLE
[feature] Check cookbook version in overcommit.

### DIFF
--- a/.git-hooks/pre_commit/cookbook_version.rb
+++ b/.git-hooks/pre_commit/cookbook_version.rb
@@ -1,0 +1,34 @@
+module Overcommit
+  module Hook
+    module PreCommit
+      # Run food critic to lint commit
+      class CookbookVersion < Base
+        def run
+          begin
+            require 'chef/cookbook/metadata'
+          rescue LoadError
+            return :stop, 'run `bundle install` to install the chef gem'
+          end
+
+          metadata = Chef::Cookbook::Metadata.new
+          metadata.from_file('metadata.rb')
+
+          current_version = metadata.version
+
+          return :fail, "Cookbook version #{current_version} already exists." if tag_exists? current_version
+
+          :pass
+        end
+
+        def tag_exists?(version)
+          begin
+            require 'git'
+          rescue LoadError
+            return :stop, 'run `bundle install` to install the git gem'
+          end
+          Git.open(::Dir.pwd).tags.map { |tag| tag.name.delete('v') }.include? version
+        end
+      end
+    end
+  end
+end

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver_plugin: vagrant
 driver_config:
-  require_chef_omnibus: 11.16.4
+  require_chef_omnibus: 12.6.0
   customize:
     natdnshostresolver1: "on"
     memory: 2048

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -29,6 +29,10 @@ PreCommit:
   ShellCheck:
     enabled: false
 
+  CookbookVersion:
+    description: 'Checking for updated cookbook version'
+    enabled: true
+
 #PostCheckout:
 #  ALL: # Special hook name that customizes all hooks of this type
 #   quiet: true # Change all post-checkout hooks to only display output on failure

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ end
 
 group :development do
   gem 'overcommit'
+  gem 'git'
+  gem 'chef', '~> 12.6.0'
   gem 'guard'
   gem 'guard-kitchen'
   gem 'guard-rubocop'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'devops@optoro.com'
 license 'MIT'
 description 'This is a skeleton'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.18'
+version '0.0.19'
 
 supports 'ubuntu', '= 14.04'
 


### PR DESCRIPTION
This change adds an overcommit hook that checks the current cookbook version
against the available version tags in the git repo. If the version already exists, the
commit will fail.